### PR TITLE
Use cloudinary.v2.uploader.explicit instead of cloudinary.v2.api.resource

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,10 @@ class CloudinaryAdapter extends BaseAdapter{
 
   exists(filename) {
     return new BlueBird(function(resolve) {
-      cloudinary.v2.api.resource(path.parse(filename).name, {type: 'upload'}, function(error, result) {
+      // Use explicit instead of resource because there's no rate limit for explicit
+      cloudinary.v2.uploader.explicit(path.parse(filename).name, {type: 'upload'}, function(error, result) {
         if (result) {
-          resolve(result);
+          resolve(true);
         } else {
           resolve(false);
         }

--- a/test/test.js
+++ b/test/test.js
@@ -14,12 +14,12 @@ var baseConfig = {
             "secure": "true"
         },
         "file": {
-            "use_filename": "true", 
-            "unique_filename": "false", 
-            "phash": "true", 
-            "overwrite": "false", 
+            "use_filename": "true",
+            "unique_filename": "false",
+            "phash": "true",
+            "overwrite": "false",
             "invalidate": "true"
-        }       
+        }
     }
   };
 
@@ -35,11 +35,11 @@ function generateImage(imageFile, imageName) {
 describe('Image Upload', function () {
     var result = false;
 
-    var uploadExistsResult = { 
-        public_id: 'favicon', 
+    var uploadExistsResult = {
+        public_id: 'favicon',
         version: 1505580646,
-        signature: 'd67f55bc2759623a5977c148942d33d7c55b55c9', 
-        width: 96, 
+        signature: 'd67f55bc2759623a5977c148942d33d7c55b55c9',
+        width: 96,
         height: 96,
         format: 'png',
         resource_type: 'image',
@@ -49,14 +49,14 @@ describe('Image Upload', function () {
         type: 'upload',
         url: 'http://res.cloudinary.com/blog-mornati-net/image/upload/v1505580646/favicon.png',
         secure_url: 'https://res.cloudinary.com/blog-mornati-net/image/upload/v1505580646/favicon.png',
-        existing: true 
+        existing: true
     };
 
     before(function () {
-        cloudinaryAdapter = new CloudinaryAdapter(baseConfig); 
+        cloudinaryAdapter = new CloudinaryAdapter(baseConfig);
     });
 
-    it("should report OK for upload", function(done){ 
+    it("should report OK for upload", function(done){
         image = generateImage("favicon.png");
 
         sinon.stub(cloudinary.uploader, 'upload');
@@ -64,26 +64,25 @@ describe('Image Upload', function () {
         sinon.stub(cloudinary, 'url').callsFake(function fakeFn() {
             return "https://res.cloudinary.com/blog-mornati-net/image/upload/q_auto:good/favicon.png";
         });
-        
+
         var promise = cloudinaryAdapter.save(image, "");
         promise.then(function(value){
             result = value;
             expect(result).equals("https://res.cloudinary.com/blog-mornati-net/image/upload/q_auto:good/favicon.png");
             done();
         });
-
     });
 
-    it("should remove spaces before upload", function(done){ 
+    it("should remove spaces before upload", function(done){
         image = generateImage("favicon.png", "favicon with spaces.png");
         console.log(image);
-        var expectedConfig = { 
+        var expectedConfig = {
             use_filename: 'true',
             unique_filename: 'false',
             phash: 'true',
             overwrite: 'false',
             invalidate: 'true',
-            public_id: 'favicon-with-spaces' 
+            public_id: 'favicon-with-spaces'
         };
 
         sinon.stub(cloudinary.uploader, 'upload').withArgs(image.path, sinon.match.any, expectedConfig).callsArgWith(1, uploadExistsResult);
@@ -103,16 +102,11 @@ describe('Image Upload', function () {
         cloudinary.uploader.upload.restore(); // Unwraps the spy
         cloudinary.url.restore();
     });
-  
-    after(function () {
-  
-    });
 });
 
 describe('Image Exists', function () {
     var result = false;
-
-    var resultExists = { 
+    var resultExists = {
         public_id: 'favicon',
         format: 'png',
         version: 1505580968,
@@ -123,53 +117,38 @@ describe('Image Exists', function () {
         width: 96,
         height: 96,
         url: 'http://res.cloudinary.com/blog-mornati-net/image/upload/v1505580968/favicon.png',
-        secure_url: 'https://res.cloudinary.com/blog-mornati-net/image/upload/v1505580968/favicon.png',
-        next_cursor: '66902c8d3e20eb6ad26fd1cd3ada3188',
-        derived:
-        [ { transformation: 't_media_lib_thumb',
-            format: 'png',
-            bytes: 5473,
-            id: 'd3b76a74b046c9fafaf2254d9bb7feab',
-            url: 'http://res.cloudinary.com/blog-mornati-net/image/upload/t_media_lib_thumb/v1505580968/favicon.png',
-            secure_url: 'https://res.cloudinary.com/blog-mornati-net/image/upload/t_media_lib_thumb/v1505580968/favicon.png' } ],
-        rate_limit_allowed: 500,
-        rate_limit_reset_at: "2017-09-16T19:00:00.000Z",
-        rate_limit_remaining: 499 
+        secure_url: 'https://res.cloudinary.com/blog-mornati-net/image/upload/v1505580968/favicon.png'
     };
 
     before(function () {
         cloudinaryAdapter = new CloudinaryAdapter(baseConfig);
-        sinon.stub(cloudinary.v2.api, 'resource');
+        sinon.stub(cloudinary.v2.uploader, 'explicit');
     });
 
     it("should find an image", function(done){
-        cloudinary.v2.api.resource.callsArgWith(2, undefined, resultExists);
+        cloudinary.v2.uploader.explicit.callsArgWith(2, undefined, resultExists);
 
         image = generateImage("favicon.png");
 
         var promise = cloudinaryAdapter.exists(image.name);
-        
+
         promise.then(function(value){
-            expect(value).to.have.deep.property('public_id', "favicon");
+            expect(value).to.equals(true);
             done();
         });
     });
 
     it("should not find an image", function(done){
-        cloudinary.v2.api.resource.callsArgWith(2, {error: "error"}, undefined);
+        cloudinary.v2.uploader.explicit.callsArgWith(2, {error: "error"}, undefined);
 
         image = generateImage("favicon.png");
 
         var promise = cloudinaryAdapter.exists(image.name);
-        
+
         promise.then(function(value){
             expect(value).equals(false);
             done();
         });
-    });
-  
-    after(function () {
-  
     });
 });
 
@@ -177,7 +156,7 @@ describe('Image Delete', function () {
     var result = false;
 
     before(function () {
-        cloudinaryAdapter = new CloudinaryAdapter(baseConfig); 
+        cloudinaryAdapter = new CloudinaryAdapter(baseConfig);
         sinon.stub(cloudinary.uploader, 'destroy');
     });
 
@@ -185,7 +164,7 @@ describe('Image Delete', function () {
         image = generateImage("favicon.png");
         cloudinary.uploader.destroy.callsArgWith(1, {"result":"ok"});
         var promise = cloudinaryAdapter.delete(image.name);
-        
+
         promise.then(function(value){
             expect(value).to.have.deep.property('result', "ok");
             done();
@@ -196,37 +175,24 @@ describe('Image Delete', function () {
         image = generateImage("missing_image.png");
         cloudinary.uploader.destroy.callsArgWith(1, {"result":"not found"});
         var promise = cloudinaryAdapter.delete(image.name);
-        
+
         promise.then(function(value){
             expect(value).to.have.deep.property('result', "not found");
             done();
         });
     });
-  
-    after(function () {
-  
-    });
   });
 
   describe('Image Read', function () {
-
-    before(function () {
-        
-    });
-
     it("should find the image", function(done){
         var res = {"body": "imagecontent"};
         sinon.stub(request, 'get').yields(undefined, JSON.stringify(res));
         var options = {"path": "https://blog.mornati.net/myimage.png"};
         var promise = cloudinaryAdapter.read(options);
-        
+
         promise.then(function(value){
             done();
         });
-    });
-  
-    after(function () {
-  
     });
   });
 


### PR DESCRIPTION
Hello Marco,

I'm recently trying to migrate all my images to Cloudinary so I'm diving into your code to see how it works. First of all, thank you for your work here.

Here a small PR to improve the behavior of `exists`:

- Returns explicit a boolean (to follow Ghost storage interface)
- Use `cloudinary.v2.uploader.explicit` because it's not rate limited as opposed as `cloudinary.v2.api.resource`

> Note that if you only need details about the original resource, you can also use the upload or explicit methods, which are not rate limited.

PS: you find a better way to review the PR with the [?w=1 param](https://github.com/mmornati/ghost-cloudinary-store/pull/12/files?w=1).